### PR TITLE
[CRM] Update `endpoint.create` to support `connector_id` in query params

### DIFF
--- a/ruby/lib/svix/api/endpoint.rb
+++ b/ruby/lib/svix/api/endpoint.rb
@@ -24,10 +24,11 @@ module Svix
     end
 
     def create(app_id, endpoint_in, options = {})
-      path = "/api/v1/app/#{app_id}/endpoint"
       options = options.transform_keys(&:to_s)
 
       connector_id = options["connector_id"]
+      
+      path = "/api/v1/app/#{app_id}/endpoint"
       path += "?connector_id=#{connector_id}" if connector_id
 
       res = @client.execute_request(

--- a/ruby/lib/svix/api/endpoint.rb
+++ b/ruby/lib/svix/api/endpoint.rb
@@ -24,10 +24,15 @@ module Svix
     end
 
     def create(app_id, endpoint_in, options = {})
+      path = "/api/v1/app/#{app_id}/endpoint"
       options = options.transform_keys(&:to_s)
+
+      connector_id = options["connector_id"]
+      path += "?connector_id=#{connector_id}" if connector_id
+
       res = @client.execute_request(
         "POST",
-        "/api/v1/app/#{app_id}/endpoint",
+        path,
         headers: {
           "idempotency-key" => options["idempotency-key"]
         },

--- a/ruby/lib/svix/models/endpoint_in.rb
+++ b/ruby/lib/svix/models/endpoint_in.rb
@@ -6,6 +6,7 @@ module Svix
   class EndpointIn
     # List of message channels this endpoint listens to (omit for all).
     attr_accessor :channels
+    attr_accessor :connector_id
     attr_accessor :description
     attr_accessor :disabled
     attr_accessor :filter_types
@@ -24,6 +25,7 @@ module Svix
 
     ALL_FIELD ||= [
       "channels",
+      "connector_id",
       "description",
       "disabled",
       "filter_types",
@@ -56,6 +58,7 @@ module Svix
       attributes = attributes.transform_keys(&:to_s)
       attrs = Hash.new
       attrs["channels"] = attributes["channels"]
+      attrs["connector_id"] = attributes["connectorId"]
       attrs["description"] = attributes["description"]
       attrs["disabled"] = attributes["disabled"]
       attrs["filter_types"] = attributes["filterTypes"]
@@ -72,6 +75,7 @@ module Svix
     def serialize
       out = Hash.new
       out["channels"] = Svix::serialize_primitive(@channels) if @channels
+      out["connectorId"] = Svix::serialize_primitive(@connector_id) if @connector_id
       out["description"] = Svix::serialize_primitive(@description) if @description
       out["disabled"] = Svix::serialize_primitive(@disabled) if @disabled
       out["filterTypes"] = Svix::serialize_primitive(@filter_types) if @filter_types

--- a/ruby/lib/svix/models/endpoint_in.rb
+++ b/ruby/lib/svix/models/endpoint_in.rb
@@ -6,7 +6,6 @@ module Svix
   class EndpointIn
     # List of message channels this endpoint listens to (omit for all).
     attr_accessor :channels
-    attr_accessor :connector_id
     attr_accessor :description
     attr_accessor :disabled
     attr_accessor :filter_types
@@ -25,7 +24,6 @@ module Svix
 
     ALL_FIELD ||= [
       "channels",
-      "connector_id",
       "description",
       "disabled",
       "filter_types",
@@ -58,7 +56,6 @@ module Svix
       attributes = attributes.transform_keys(&:to_s)
       attrs = Hash.new
       attrs["channels"] = attributes["channels"]
-      attrs["connector_id"] = attributes["connectorId"]
       attrs["description"] = attributes["description"]
       attrs["disabled"] = attributes["disabled"]
       attrs["filter_types"] = attributes["filterTypes"]
@@ -75,7 +72,6 @@ module Svix
     def serialize
       out = Hash.new
       out["channels"] = Svix::serialize_primitive(@channels) if @channels
-      out["connectorId"] = Svix::serialize_primitive(@connector_id) if @connector_id
       out["description"] = Svix::serialize_primitive(@description) if @description
       out["disabled"] = Svix::serialize_primitive(@disabled) if @disabled
       out["filterTypes"] = Svix::serialize_primitive(@filter_types) if @filter_types


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We are forking the `svix` gem because we want to provide support to pass `connector_id` when creating a svix endpoint. This is currently not supported in the SDK but will be in the future. At which point, we can go back to using the original svix gem repo. This PR updates the `endpoint.create` method to add `query_params` to the URL path if `connector_id` is passed as an option. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
